### PR TITLE
Convert header response to strings instead of symbols

### DIFF
--- a/lib/apicraft/middlewares/introspector.rb
+++ b/lib/apicraft/middlewares/introspector.rb
@@ -25,7 +25,7 @@ module Apicraft
 
         [
           200,
-          { 'Content-Type': "application/json" },
+          { "Content-Type" => "application/json" },
           [schema.to_json]
         ]
       end

--- a/lib/apicraft/middlewares/mocker.rb
+++ b/lib/apicraft/middlewares/mocker.rb
@@ -30,7 +30,7 @@ module Apicraft
         [
           code.to_i,
           {
-            'Content-Type': content_type
+            "Content-Type" => content_type
           },
           [
             content&.send(convertor(content_type))

--- a/lib/apicraft/middlewares/request_validator.rb
+++ b/lib/apicraft/middlewares/request_validator.rb
@@ -31,7 +31,7 @@ module Apicraft
       rescue OpenAPIParser::OpenAPIError => e
         [
           config.request_validation_http_code,
-          { 'Content-Type': content_type },
+          { "Content-Type" => content_type },
           [
             response_body(e)&.send(convertor(content_type))
           ].compact

--- a/lib/apicraft/web/app.rb
+++ b/lib/apicraft/web/app.rb
@@ -23,19 +23,19 @@ module Apicraft
 
         [
           200,
-          { 'Content-Type': content_type },
+          { 'Content-Type' => content_type },
           [content]
         ]
       rescue Errors::RouteNotFound
         [
           404,
-          { 'Content-Type': "text/plain" },
+          { 'Content-Type' => "text/plain" },
           ["Error: not found"]
         ]
       rescue StandardError => e
         [
           500,
-          { 'Content-Type': "text/plain" },
+          { 'Content-Type' => "text/plain" },
           ["Error: #{e.message}"]
         ]
       end
@@ -54,8 +54,8 @@ module Apicraft
         [
           401,
           {
-            "Content-Type": "text/plain",
-            "WWW-Authenticate": "Basic realm=\"Restricted Area\""
+            "Content-Type" => "text/plain",
+            "WWW-Authenticate" => "Basic realm=\"Restricted Area\""
           },
           ["Unauthorized"]
         ]

--- a/lib/apicraft/web/app.rb
+++ b/lib/apicraft/web/app.rb
@@ -23,19 +23,19 @@ module Apicraft
 
         [
           200,
-          { 'Content-Type' => content_type },
+          { "Content-Type" => content_type },
           [content]
         ]
       rescue Errors::RouteNotFound
         [
           404,
-          { 'Content-Type' => "text/plain" },
+          { "Content-Type" => "text/plain" },
           ["Error: not found"]
         ]
       rescue StandardError => e
         [
           500,
-          { 'Content-Type' => "text/plain" },
+          { "Content-Type" => "text/plain" },
           ["Error: #{e.message}"]
         ]
       end


### PR DESCRIPTION
Hey!

I wanted to try out your framework, but the swagger route wouldn't load at all. I tracked it down to Puma throwing an error because the response headers were set using `{ key: value }` instead of `{ key => value}`. This turns the key into a symbol, which makes Puma throw a TypeError. 

https://medium.com/@ssscripting/puma-typeerror-no-implicit-conversion-of-symbol-into-string-d58df06a780b

Just wanted to let you know, since a lot of people are probably running Puma 😊